### PR TITLE
__init__.py imports

### DIFF
--- a/pinax/identity/__init__.py
+++ b/pinax/identity/__init__.py
@@ -4,5 +4,5 @@ import pkg_resources
 __version__ = pkg_resources.get_distribution("pinax-identity").version
 
 
-from .authentication import TokenAuthentication  #noqa
+from .authentication import TokenAuthentication  # noqa
 from .permissions import ensure_scope  # noqa

--- a/pinax/identity/__init__.py
+++ b/pinax/identity/__init__.py
@@ -2,3 +2,6 @@ import pkg_resources
 
 
 __version__ = pkg_resources.get_distribution("pinax-identity").version
+
+
+from . import authentication, permissions  # noqa

--- a/pinax/identity/__init__.py
+++ b/pinax/identity/__init__.py
@@ -4,4 +4,5 @@ import pkg_resources
 __version__ = pkg_resources.get_distribution("pinax-identity").version
 
 
-from . import authentication, permissions  # noqa
+from .authentication import TokenAuthentication  #noqa
+from .permissions import ensure_scope  # noqa


### PR DESCRIPTION
This change permits imports following the (apparent) Pinax standard:

``` python
from pinax import identity

    ...
    identity.ensure_scope()
```
