### PR TITLE
Add Django-style authentication middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Add to urls.py:
         ...
     ]
 
+Add authentication middleware to MIDDLEWARE_CLASSES:
+
+    MIDDLEWARE_CLASSES = [
+        "pinax.identity.middleware.AuthenticationMiddleware",
+        ...
+    ]
+
 Most likely you'll need to handle CORS, use django-cors-headers. Add the
 middleware to the top of MIDDLEWARE_CLASSES:
 

--- a/pinax/identity/middleware.py
+++ b/pinax/identity/middleware.py
@@ -1,0 +1,32 @@
+from oidc_provider.lib.utils.oauth2 import extract_access_token
+from oidc_provider.models import Token
+
+from django.contrib import auth
+from django.utils.functional import SimpleLazyObject
+
+
+class AuthenticationMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        access_token = extract_access_token(request)
+        try:
+            token = Token.objects.get(access_token=access_token)
+        except Token.DoesNotExist:
+            self.unauthenticated(request)
+        else:
+            if not token.has_expired():
+                self.authenticated(request, token)
+            else:
+                self.unauthenticated(request)
+        return self.get_response(request)
+
+    def unauthenticated(self, request):
+        request.token = None
+        request.user = SimpleLazyObject(lambda: auth.get_user(request))
+
+    def authenticated(self, request, token):
+        request.token = token
+        request.user = token.user

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="",
     name="pinax-identity",
     long_description=read("README.md"),
-    version="0.1.0",
+    version="0.2.0",
     url="http://github.com/pinax/pinax-identity/",
     license="MIT",
     packages=find_packages(),


### PR DESCRIPTION
Add `AuthenticationMiddleware` class for authenticating OIDC token-based authentication. If the token does not exist, sets request.user to AnonymousUser. (Middleware code by @brosner.)