### PR TITLE
Add middleware tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.eggs/
+build
+dist
+.coverage
+.tox
+MANIFEST
+*.pyc
+*.egg-info
+*.egg
+docs/_build/
+htmlcov/
+.python-version
+# Pycharm
+.idea

--- a/pinax/identity/middleware.py
+++ b/pinax/identity/middleware.py
@@ -6,10 +6,15 @@ from django.contrib.auth.models import AnonymousUser
 
 class AuthenticationMiddleware:
 
-    def __init__(self, get_response):
-        self.get_response = get_response
+    def __init__(self, get_response=None):
+        if get_response:
+            self.get_response = get_response
 
     def __call__(self, request):
+        self.process_request(request)
+        return self.get_response(request)
+
+    def process_request(self, request):
         access_token = extract_access_token(request)
         try:
             token = Token.objects.get(access_token=access_token)
@@ -20,7 +25,6 @@ class AuthenticationMiddleware:
                 self.authenticated(request, token)
             else:
                 self.unauthenticated(request)
-        return self.get_response(request)
 
     def unauthenticated(self, request):
         request.token = None

--- a/pinax/identity/test.py
+++ b/pinax/identity/test.py
@@ -1,0 +1,85 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.test.client import (
+    Client as TestClient,
+    FakePayload,
+)
+from django.utils import six
+from django.utils.encoding import force_bytes, force_str
+from django.utils.six.moves.urllib.parse import urlparse
+
+from oidc_provider.models import Client
+
+
+class TokenizingClient(TestClient):
+    """
+    If `self.token` is present, sets "BEARER" header with access token.
+    """
+
+    def generic(self, method, path, data='',
+                content_type='application/octet-stream', secure=False,
+                **extra):
+        """Constructs an arbitrary HTTP request."""
+        parsed = urlparse(force_str(path))
+        data = force_bytes(data, settings.DEFAULT_CHARSET)
+        r = {
+            'PATH_INFO': self._get_path(parsed),
+            'REQUEST_METHOD': str(method),
+            'SERVER_PORT': str('443') if secure else str('80'),
+            'wsgi.url_scheme': str('https') if secure else str('http'),
+        }
+        if data:
+            r.update({
+                'CONTENT_LENGTH': len(data),
+                'CONTENT_TYPE': str(content_type),
+                'wsgi.input': FakePayload(data),
+            })
+
+        if hasattr(self, 'token'):
+            r.update({'HTTP_AUTHORIZATION': "Bearer {}".format(self.token.access_token)})
+
+        r.update(extra)
+        # If QUERY_STRING is absent or empty, we want to extract it from the URL.
+        if not r.get('QUERY_STRING'):
+            query_string = force_bytes(parsed[4])
+            # WSGI requires latin-1 encoded strings. See get_path_info().
+            if six.PY3:
+                query_string = query_string.decode('iso-8859-1')
+            r['QUERY_STRING'] = query_string
+        return self.request(**r)
+
+
+class IdentityTestCase(TestCase):
+
+    maxDiff = None
+    client_class = TokenizingClient
+
+    def setUp(self):
+        super(IdentityTestCase, self).setUp()
+
+        usermodel = get_user_model()
+
+        # Create User for access token
+        self.user_password = "changeme"
+        self.login_user = usermodel.objects.create(
+            username="loginuser",
+            email="login_user@example.com",
+            password=self.user_password,
+            first_name="Login",
+            last_name="User"
+        )
+
+        # Create access client
+        self.oidc_client = Client.objects.create(
+            name="oidc client",
+            client_type="public",
+            client_id="000001",
+            response_type="id_token token",
+        )
+
+    def tokenize_url(self, url):
+        if "?" in url:
+            return "{}&access_token={}".format(url, self.token.access_token)
+        else:
+            return "{}?access_token={}".format(url, self.token.access_token)

--- a/pinax/identity/tests/templates/homepage.html
+++ b/pinax/identity/tests/templates/homepage.html
@@ -1,0 +1,7 @@
+<head>
+</head>
+
+<body>
+  <div>Welcome to pinax-identity!</div>
+  <div>User={{ request.user }}</div>
+</body>

--- a/pinax/identity/tests/test_middleware.py
+++ b/pinax/identity/tests/test_middleware.py
@@ -1,0 +1,65 @@
+import datetime
+import pytz
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.core.urlresolvers import reverse
+
+from oidc_provider.models import Token
+
+from ..test import IdentityTestCase
+
+
+class MiddlewareTestCase(IdentityTestCase):
+
+    def setUp(self):
+        super(MiddlewareTestCase, self).setUp()
+        self.home_url = reverse("home")
+
+    def test_anonymous(self):
+        """
+        Ensure request with no token results in response.context user==AnonymousUser
+        """
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 200)
+        user = response.context["user"]
+        self.assertTrue(isinstance(user, AnonymousUser))
+
+    def test_authenticated(self):
+        """
+        Ensure request with valid token results in response.context user==AuthUser
+        """
+        # Create valid access token
+        self.token = Token.objects.create(
+            user=self.login_user,
+            client=self.oidc_client,
+            expires_at=datetime.datetime(year=2100, month=1, day=1, tzinfo=pytz.utc),
+            access_token="690c5505b06e44d4bf2215a4413c3b6b",
+            _id_token="thisistheidtoken"
+        )
+        self.client.token = self.token
+
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 200)
+        user = response.context["user"]
+        self.assertFalse(isinstance(user, AnonymousUser))
+        self.assertTrue(isinstance(user, get_user_model()))
+
+    def test_expired_token(self):
+        """
+        Ensure request with expired token results in response.context user==AnonymousUser
+        """
+        # Create expired access token
+        self.token = Token.objects.create(
+            user=self.login_user,
+            client=self.oidc_client,
+            expires_at=datetime.datetime(year=2000, month=1, day=1, tzinfo=pytz.utc),
+            access_token="690c5505b06e44d4bf2215a4413c3b6b",
+            _id_token="thisistheidtoken"
+        )
+        self.client.token = self.token
+
+        response = self.client.get(self.home_url)
+        self.assertEqual(response.status_code, 200)
+        user = response.context["user"]
+        self.assertTrue(isinstance(user, AnonymousUser))

--- a/pinax/identity/tests/urls.py
+++ b/pinax/identity/tests/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+from django.views.generic import TemplateView
+
+
+urlpatterns = [
+    url(r"^$", TemplateView.as_view(template_name="homepage.html"), name="home"),
+]

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+
+from django.conf import settings
+
+
+DEFAULT_SETTINGS = dict(
+    INSTALLED_APPS=[
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.sites",
+        "django.contrib.sessions",
+        "oidc_provider",
+        "pinax.identity",
+        "pinax.identity.tests"
+    ],
+    MIDDLEWARE_CLASSES=[
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "pinax.identity.middleware.AuthenticationMiddleware",
+    ],
+    DATABASES={
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    },
+    SITE_ID=1,
+    ROOT_URLCONF="pinax.identity.tests.urls",
+    SECRET_KEY="notasecret",
+    AUTHENTICATION_BACKENDS=[
+        "django.contrib.auth.backends.ModelBackend",
+    ],
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "debug": True,
+                "context_processors": [
+                    "django.contrib.auth.context_processors.auth",
+                ]
+            }
+        },
+    ],
+    USE_TZ=True
+)
+
+
+def runtests(*test_args):
+    if not settings.configured:
+        settings.configure(**DEFAULT_SETTINGS)
+
+    django.setup()
+
+    parent = os.path.dirname(os.path.abspath(__file__))
+    sys.path.insert(0, parent)
+
+    try:
+        from django.test.runner import DiscoverRunner
+        runner_class = DiscoverRunner
+        test_args = ["pinax.identity.tests"]
+    except ImportError:
+        from django.test.simple import DjangoTestSuiteRunner
+        runner_class = DjangoTestSuiteRunner
+        test_args = ["tests"]
+
+    failures = runner_class(verbosity=1, interactive=True, failfast=False).run_tests(test_args)
+    sys.exit(failures)
+
+
+if __name__ == "__main__":
+    runtests(*sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(*parts):
 setup(
     author="Pinax Developers",
     author_email="developers@pinaxproject.com",
-    description="",
+    description="a helper package for Open ID Connect authentication",
     name="pinax-identity",
     long_description=read("README.md"),
     version="0.2.0",
@@ -23,6 +23,10 @@ setup(
     package_data={
         "identity": []
     },
+    test_suite="runtests.runtests",
+    tests_require=[
+        "pytz==2016.6.1",
+    ],
     install_requires=[
         "django-oidc-provider==0.3.6",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[flake8]
+ignore = E265,E501
+max-line-length = 100
+max-complexity = 10
+exclude = migrations/*,docs/*
+
+[tox]
+envlist =
+    py27-{1.8,1.9,1.10,master},
+    py33-{1.8},
+    py34-{1.8,1.9,1.10,master},
+    py35-{1.8,1.9,1.10,master}
+
+[testenv]
+deps =
+    coverage == 4.0.2
+    flake8 == 2.5.0
+    1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
+    1.10: Django>=1.10,<1.11
+    master: https://github.com/django/django/tarball/master
+usedevelop = True
+setenv =
+   LANG=en_US.UTF-8
+   LANGUAGE=en_US:en
+   LC_ALL=en_US.UTF-8
+commands =
+    flake8 pinax
+    coverage run setup.py test


### PR DESCRIPTION
Include Django 1.10 in test matrix.

`AuthenticationMiddleware.__init__()` is designed to work with Django v1.9 and earlier as well as new MIDDLEWARE (Django v1.10+).

Added `AuthenticationMiddleware.process_request()` to handle Django v1.9 and earlier.

Added `identity.test.TokenizingClient`, an alternate test client that sets a token on every request if available. This might want refactoring, but it works now. To use, set `self.client.token = your_token` prior to calling self.client.<method>().